### PR TITLE
Do not redirect links to chat profiles

### DIFF
--- a/ActivityTabDefault.user.js
+++ b/ActivityTabDefault.user.js
@@ -10,7 +10,8 @@
 // @match       *://*.askubuntu.com/users/*
 // @match       *://*.mathoverflow.net/users/*
 // @match       *://*.stackapps.com/users/*
-// @version     1.3
+// @exclude     *://chat.*
+// @version     1.4
 // @grant       none
 // @run-at      document-start
 // ==/UserScript==


### PR DESCRIPTION
The script currently attempts to redirect chat profiles such as https://chat.meta.stackexchange.com/users/266345/smokedetector which throws a 404 error. @exclude corrects this.