### PR TITLE
Now works on SO Teams. Misc housekeeping, see below:

### DIFF
--- a/ActivityTabDefault.user.js
+++ b/ActivityTabDefault.user.js
@@ -1,23 +1,35 @@
-// ==UserScript==
-// @name        'Activity' tab as default
-// @namespace   http://stackexchange.com/users/3094403/programfox
-// @author      ProgramFOX
-// @description A userscript that automatically shows the Activity tab as default on profile pages
-// @match       *://*.stackexchange.com/users/*
-// @match       *://*.stackoverflow.com/users/*
-// @match       *://*.superuser.com/users/*
-// @match       *://*.serverfault.com/users/*
-// @match       *://*.askubuntu.com/users/*
-// @match       *://*.mathoverflow.net/users/*
-// @match       *://*.stackapps.com/users/*
-// @exclude     *://chat.*
-// @version     1.4
-// @grant       none
-// @run-at      document-start
-// ==/UserScript==
+    // ==UserScript==
+    // @name        Stack Exchange, 'Activity' tab as the default
+    // @description A userscript that automatically shows the Activity tab as default on profile pages
+    // @match       *://*.askubuntu.com/users/*
+    // @match       *://*.mathoverflow.net/users/*
+    // @match       *://*.serverfault.com/users/*
+    // @match       *://*.stackapps.com/users/*
+    // @match       *://*.stackexchange.com/users/*
+    // @match       *://*.stackoverflow.com/users/*
+    // @match       *://*.superuser.com/users/*
+    // @match       *://*.stackoverflow.com/c/*/users/*
+    // @exclude     *://*/review
+    // @exclude     *://api.stackexchange.com/*
+    // @exclude     *://blog.*.com/*
+    // @exclude     *://chat.*.com/*
+    // @exclude     *://data.stackexchange.com/*
+    // @exclude     *://elections.stackexchange.com/*
+    // @exclude     *://openid.stackexchange.com/*
+    // @exclude     *://stackexchange.com/*
+    // @grant       none
+    // @run-at      document-start
+    // @version     2.0
+    // @history     2.0 Added support for Stack Overflow teams
+    // @author      ProgramFOX and Brock Adams
+    // @homepage    https://stackapps.com/q/6267/7653
+    // ==/UserScript==
+    /* eslint-disable no-multi-spaces */
 
-if (!window.location.search &&
-    !window.location.hash &&
-    !(/\/users\/edit\/|\/login\b/i).test(window.location.pathname)) {
-    window.location.replace(window.location.href + "?tab=topactivity");
-}
+    if (    ! location.search   &&
+            ! location.hash     &&
+            ! /^chat\./.test (location.host)    &&
+            ! /\/users\/edit\/|\/login\b|\/flag-summary/.test (location.pathname)
+    ) {
+        location.replace (location.href + "?tab=topactivity");
+    }


### PR DESCRIPTION
- Now works correctly for users in [Stack Overflow Teams](https://meta.stackoverflow.com/tags/stack-overflow-for-teams/info)
 - Scope/SEO the title.
 - Expanded the list of inapplicable pages to not run on.
 - Link to the Stack Apps listing page. See the effect in the Tampermonkey dashboard.
- Added metadata used by Tampermonkey and other userscript engines.